### PR TITLE
Refactor: Improve app settings management and code readability

### DIFF
--- a/app/src/main/java/ir/saltech/puyakhan/data/util/ToolFunctions.kt
+++ b/app/src/main/java/ir/saltech/puyakhan/data/util/ToolFunctions.kt
@@ -2,20 +2,15 @@ package ir.saltech.puyakhan.data.util
 
 import android.content.Context
 import android.util.Log
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 private const val APPLICATION_DATASTORE = "app_data"
 
@@ -23,27 +18,17 @@ private const val DATASTORE_TAG = "APP_DATA_STORE"
 
 internal val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = APPLICATION_DATASTORE)
 
-internal operator fun <T> DataStore<Preferences>.get(key: Preferences.Key<T>): T? {
-	var dataFlow: T? = null
-	runBlocking {
-		launch {
-			dataFlow = data.map { preferences ->
-				preferences[key]
-			}.first()
-			Log.w(DATASTORE_TAG, "Loading app settings...")
-		}
-	}
-	return dataFlow
+internal suspend operator fun <T> DataStore<Preferences>.get(key: Preferences.Key<T>): T? {
+	Log.w(DATASTORE_TAG, "Loading app settings key $key...")
+	return data.map { preferences ->
+		preferences[key]
+	}.first()
 }
 
-internal operator fun <T> DataStore<Preferences>.set(key: Preferences.Key<T>, value: T) {
-	runBlocking {
-		launch {
-			edit { preferences ->
-				preferences[key] = value
-			}
-			Log.w(DATASTORE_TAG, "Saving app settings...")
-		}
+internal suspend operator fun <T> DataStore<Preferences>.set(key: Preferences.Key<T>, value: T) {
+	Log.w(DATASTORE_TAG, "Saving app settings key $key...")
+	edit { preferences ->
+		preferences[key] = value
 	}
 }
 
@@ -61,4 +46,13 @@ internal infix fun Long.past(much: Long): Long {
 
 internal infix operator fun Long.div(l: Long): Float {
 	return (this.toDouble() / l.toDouble()).toFloat()
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun repeatForever(action: () -> Unit) {
+	contract { callsInPlace(action) }
+
+	while (true) {
+		action()
+	}
 }

--- a/app/src/main/java/ir/saltech/puyakhan/ui/theme/Symbols.kt
+++ b/app/src/main/java/ir/saltech/puyakhan/ui/theme/Symbols.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 
 internal object Symbols {
 	object Default {
-		val Disclaimer: ImageVector
+		val Privacy: ImageVector
 			@Composable get() = rememberBalance()
 		val NewTab: ImageVector
 			@Composable get() = rememberOpenInNew()

--- a/app/src/main/java/ir/saltech/puyakhan/ui/view/activity/BackgroundActivity.kt
+++ b/app/src/main/java/ir/saltech/puyakhan/ui/view/activity/BackgroundActivity.kt
@@ -18,8 +18,8 @@ internal class BackgroundActivity : ComponentActivity() {
 		if (intent != null) {
 			val extras = intent.extras
 			if (extras != null) {
-				if (extras.containsKey(App.Key.CopyOtpCode)) {
-					otp = extras.getString(App.Key.CopyOtpCode, null)
+				if (extras.containsKey(App.Key.OTP_CODE_COPY_KEY)) {
+					otp = extras.getString(App.Key.OTP_CODE_COPY_KEY, null)
 				}
 			}
 		}

--- a/app/src/main/java/ir/saltech/puyakhan/ui/view/component/adapter/OtpCodesViewAdapter.kt
+++ b/app/src/main/java/ir/saltech/puyakhan/ui/view/component/adapter/OtpCodesViewAdapter.kt
@@ -21,6 +21,9 @@ import ir.saltech.puyakhan.R
 import ir.saltech.puyakhan.data.model.App
 import ir.saltech.puyakhan.data.model.OtpCode
 import ir.saltech.puyakhan.data.util.CLIPBOARD_OTP_CODE
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 
 private const val INTERVAL = 1000L
@@ -40,7 +43,9 @@ internal class OtpCodesViewAdapter(private var otpCodes: List<OtpCode>) :
 
 	override fun onCreateViewHolder(p0: ViewGroup, p1: Int): OtpCodesViewHolder {
 		context = p0.context
-		appSettings = App.getSettings(context)
+		CoroutineScope(Dispatchers.IO).launch {
+			appSettings = App.getSettings(context)
+		}
 		return OtpCodesViewHolder(
 			LayoutInflater.from(p0.context).inflate(R.layout.layout_template_otp, p0, false)
 		)

--- a/app/src/main/java/ir/saltech/puyakhan/ui/view/model/OtpCodesVM.kt
+++ b/app/src/main/java/ir/saltech/puyakhan/ui/view/model/OtpCodesVM.kt
@@ -1,47 +1,44 @@
 package ir.saltech.puyakhan.ui.view.model
 
+import android.app.Application
 import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.toMutableStateList
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import ir.saltech.puyakhan.data.model.App
 import ir.saltech.puyakhan.data.model.OtpCode
 import ir.saltech.puyakhan.data.util.MAX_OTP_SMS_EXPIRATION_TIME
 import ir.saltech.puyakhan.data.util.OtpProcessor
+import ir.saltech.puyakhan.data.util.repeatForever
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-internal class OtpCodesVM : ViewModel() {
-
+internal class OtpCodesVM(application: Application) : AndroidViewModel(application) {
 	private val _otpCodes = MutableStateFlow(mutableStateListOf<OtpCode>())
 	val otpCodes: StateFlow<MutableList<OtpCode>> = _otpCodes.asStateFlow()
+	var appSettings: App.Settings? = null
+
+	init {
+		loadAppSettings()
+	}
 
 	private fun startExpirationTimer() {
 		viewModelScope.launch {
-			while (true) {
+			repeatForever {
 				val currentTime = System.currentTimeMillis()
-//				val updatedCodes = _otpCodes.value.filter { code ->
-//					currentTime - code.sentTime < appSettings.expireTime
-//				}.apply {
-//					this.forEachIndexed { index, code ->
-//						code.elapsedTime = currentTime - code.sentTime
-////						otpCodes.value[index].elapsedTime = currentTime - code.sentTime
-//					}
-//				}
-				val updatedCodes = _otpCodes.value.apply {
-					this.forEachIndexed { index, code ->
-						code.elapsedTime = currentTime - code.sentTime
-					}
-				}
-
 				_otpCodes.update {
-					updatedCodes.apply { if (all { it.elapsedTime >= MAX_OTP_SMS_EXPIRATION_TIME }) clear() }
-						.toMutableStateList()
+					it.apply {
+						forEach { code ->
+							code.elapsedTime = currentTime - code.sentTime
+						}
+						if (all { code -> code.elapsedTime >= MAX_OTP_SMS_EXPIRATION_TIME }) clear()
+					}.toMutableStateList()
 				}
 				delay(1000)
 			}
@@ -70,6 +67,18 @@ internal class OtpCodesVM : ViewModel() {
 		viewModelScope.launch {
 			_otpCodes.update { OtpProcessor.otpCodesList.toMutableStateList() }
 			Log.i("OtpCodesVM", "loadPreviousOtpCodes -> codes $_otpCodes")
+		}
+	}
+
+	fun loadAppSettings() {
+		viewModelScope.launch {
+			appSettings = App.getSettings(getApplication())
+		}
+	}
+
+	fun saveAppSettings() {
+		viewModelScope.launch {
+			App.setSettings(getApplication(), appSettings ?: return@launch)
 		}
 	}
 }

--- a/app/src/main/java/ir/saltech/puyakhan/ui/view/page/SettingsView.kt
+++ b/app/src/main/java/ir/saltech/puyakhan/ui/view/page/SettingsView.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -37,6 +39,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -50,11 +53,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat.checkSelfPermission
 import androidx.core.app.ActivityCompat.startActivityForResult
+import androidx.core.net.toUri
+import androidx.lifecycle.viewmodel.compose.viewModel
 import ir.saltech.puyakhan.R
 import ir.saltech.puyakhan.data.model.App
 import ir.saltech.puyakhan.data.model.App.PresentMethod
@@ -66,11 +72,11 @@ import ir.saltech.puyakhan.ui.view.activity.permissionLauncher
 import ir.saltech.puyakhan.ui.view.component.compose.MinimalHelpText
 import ir.saltech.puyakhan.ui.view.component.compose.OpenReferenceButton
 import ir.saltech.puyakhan.ui.view.component.compose.SegmentedButtonOrder
-import androidx.core.net.toUri
+import ir.saltech.puyakhan.ui.view.model.OtpCodesVM
 
 @Composable
 internal fun SettingsView(onPageChanged: (App.Page) -> Unit) {
-	BackHandler() {
+	BackHandler {
 		onPageChanged(App.Page.Main)
 	}
 	Scaffold(topBar = { SettingsTopBar { onPageChanged(it) } }) {
@@ -103,9 +109,18 @@ private fun SettingsTopBar(onPageChanged: (App.Page) -> Unit) {
 }
 
 @Composable
-private fun SettingsContent(paddingValues: PaddingValues = PaddingValues(0.dp)) {
+private fun SettingsContent(
+	paddingValues: PaddingValues = PaddingValues(0.dp),
+	mainViewModel: OtpCodesVM = viewModel(),
+) {
 	val context = LocalContext.current
-	val appSettings = App.getSettings(context)
+	val appSettings: App.Settings = mainViewModel.appSettings ?: App.Settings()
+	var canShowPrivacy by remember { mutableStateOf(false) }
+	if (canShowPrivacy) {
+		PrivacyAcceptation {
+			canShowPrivacy = false
+		}
+	}
 	LazyColumn(
 		modifier = Modifier
 			.padding(paddingValues)
@@ -116,26 +131,65 @@ private fun SettingsContent(paddingValues: PaddingValues = PaddingValues(0.dp)) 
 			)
 	) {
 		items(1) {
-			MethodSelection(context, appSettings)
+			MethodSelection(context, appSettings.presentMethods) { newPresentMethods ->
+				appSettings.presentMethods = newPresentMethods
+				mainViewModel.saveAppSettings()
+			}
 			Spacer(modifier = Modifier.height(4.dp))
-			ExpireTimeSelection(context, appSettings)
-			Spacer(modifier = Modifier.height(44.dp))
+			ExpireTimeSelection(appSettings.expireTime) { enteredExpiredTime ->
+				appSettings.expireTime = enteredExpiredTime
+				mainViewModel.saveAppSettings()
+			}
+			Spacer(modifier = Modifier.height(32.dp))
 			Text(
 				stringResource(R.string.referenced_settings),
 				style = MaterialTheme.typography.bodyMedium.copy(textDirection = TextDirection.ContentOrRtl),
 				modifier = Modifier
 					.fillMaxWidth()
 					.padding(horizontal = 26.dp)
+					.padding(bottom = 8.dp)
 					.alpha(0.75f)
 			)
-			Spacer(modifier = Modifier.height(5.dp))
 			GrantNotificationPermission(context)
 			GrantWindowOverlayPermission(context)
 			AllowBatteryOptimization(context)
 			Spacer(modifier = Modifier.height(16.dp))
 			if (Build.MANUFACTURER == "Xiaomi") XiaomiUsingWithCaution()
 			SomeUsefulHelps()
-			Spacer(modifier = Modifier.height(16.dp))
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(horizontal = 32.dp)
+					.padding(top = 32.dp, bottom = 16.dp),
+				horizontalArrangement = Arrangement.Center,
+				verticalAlignment = Alignment.CenterVertically
+			) {
+				Text(
+					modifier = Modifier
+						.clip(RoundedCornerShape(100.dp))
+						.clickable { canShowPrivacy = true },
+					text = " ${stringResource(R.string.privacy_dialog_title)} ",
+					style = MaterialTheme.typography.bodyMedium,
+					textAlign = TextAlign.Center,
+					textDecoration = TextDecoration.Underline
+				)
+				Text(
+					text = " • ",
+					style = MaterialTheme.typography.bodyMedium,
+					textAlign = TextAlign.Center,
+				)
+				Text(
+					modifier = Modifier
+						.clip(RoundedCornerShape(100.dp))
+						.clickable {
+							context.startActivity(Intent(Intent.ACTION_VIEW, "https://saltech.ir/terms".toUri()))
+						},
+					text = " ${stringResource(R.string.terms)} ",
+					style = MaterialTheme.typography.bodyMedium,
+					textAlign = TextAlign.Center,
+					textDecoration = TextDecoration.Underline
+				)
+			}
 		}
 	}
 }
@@ -153,13 +207,11 @@ private fun XiaomiUsingWithCaution() {
 
 @Composable
 private fun GrantWindowOverlayPermission(context: Context) {
-	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-		OpenReferenceButton(
-			title = stringResource(R.string.overlay_window_permission_button),
-			contentDescription = stringResource(R.string.overlay_window_permission_cd)
-		) {
-			grantScreenOverlayPermission(context)
-		}
+	OpenReferenceButton(
+		title = stringResource(R.string.overlay_window_permission_button),
+		contentDescription = stringResource(R.string.overlay_window_permission_cd)
+	) {
+		grantScreenOverlayPermission(context)
 	}
 }
 
@@ -186,9 +238,9 @@ private fun AllowBatteryOptimization(context: Context) {
 }
 
 @Composable
-private fun ExpireTimeSelection(context: Context, appSettings: App.Settings) {
+private fun ExpireTimeSelection(currentTimeSelection: Long, onTimeChanged: (Long) -> Unit) {
 	var expireTime by remember {
-		mutableLongStateOf(appSettings.expireTime)
+		mutableLongStateOf(currentTimeSelection)
 	}
 	Column(
 		modifier = Modifier
@@ -205,7 +257,8 @@ private fun ExpireTimeSelection(context: Context, appSettings: App.Settings) {
 				.padding(16.dp)
 				.fillMaxWidth()
 		) {
-			OutlinedTextField(value = if (expireTime >= 1) (expireTime / 60_000).toString() else "",
+			OutlinedTextField(
+				value = if (expireTime >= 1) (expireTime / 60_000).toString() else "",
 				onValueChange = { time ->
 					if (time.isEmpty()) {
 						expireTime = 0
@@ -213,8 +266,7 @@ private fun ExpireTimeSelection(context: Context, appSettings: App.Settings) {
 					}
 					if (time.toIntOrNull() in 1..3) {
 						expireTime = time.toLong() * 60_000
-						appSettings.expireTime = expireTime
-						App.setSettings(context, appSettings)
+						onTimeChanged(expireTime)
 					}
 				},
 				placeholder = {
@@ -246,9 +298,13 @@ private fun ExpireTimeSelection(context: Context, appSettings: App.Settings) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun MethodSelection(context: Context, appSettings: App.Settings) {
-	var preferredMethod by remember {
-		mutableStateOf(appSettings.presentMethods)
+private fun MethodSelection(
+	context: Context,
+	currentPreferredMethods: Set<String>,
+	onPreferredMethodChanged: (Set<String>) -> Unit,
+) {
+	var preferredMethods: Set<String> by remember {
+		mutableStateOf(currentPreferredMethods)
 	}
 	Column(
 		modifier = Modifier
@@ -270,13 +326,13 @@ private fun MethodSelection(context: Context, appSettings: App.Settings) {
 			Spacer(modifier = Modifier.height(16.dp))
 			MultiChoiceSegmentedButtonRow(modifier = Modifier.align(Alignment.CenterHorizontally)) {
 				SegmentedButton(
-					checked = preferredMethod.contains(PresentMethod.Otp.Copy),
+					checked = preferredMethods.contains(PresentMethod.Otp.COPY),
 					onCheckedChange = {
-						preferredMethod =
-							if (it) preferredMethod.plus(PresentMethod.Otp.Copy) else preferredMethod.minus(
-								PresentMethod.Otp.Copy
+						preferredMethods =
+							if (it) preferredMethods.plus(PresentMethod.Otp.COPY) else preferredMethods.minus(
+								PresentMethod.Otp.COPY
 							)
-						updatePreferredMethods(appSettings, preferredMethod, context)
+						onPreferredMethodChanged(preferredMethods)
 					},
 					shape = SegmentedButtonOrder.First,
 					//icon = { Icon(imageVector = Symbols.CopyCode, contentDescription = "Copy code method") },
@@ -287,61 +343,82 @@ private fun MethodSelection(context: Context, appSettings: App.Settings) {
 					enabled = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) (checkSelfPermission(
 						context, android.Manifest.permission.POST_NOTIFICATIONS
 					) == PackageManager.PERMISSION_GRANTED) else true,
-					checked = preferredMethod.contains(PresentMethod.Otp.Notify),
+					checked = preferredMethods.contains(PresentMethod.Otp.NOTIFY),
 					onCheckedChange = {
-						preferredMethod =
-							if (it) preferredMethod.plus(PresentMethod.Otp.Notify) else preferredMethod.minus(
-								PresentMethod.Otp.Notify
+						preferredMethods =
+							if (it) preferredMethods.plus(PresentMethod.Otp.NOTIFY) else preferredMethods.minus(
+								PresentMethod.Otp.NOTIFY
 							)
-						updatePreferredMethods(appSettings, preferredMethod, context)
+						onPreferredMethodChanged(preferredMethods)
 					},
-					shape = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) SegmentedButtonOrder.Middle else SegmentedButtonOrder.Last
+					shape = SegmentedButtonOrder.Middle
 				) {
 					Text(text = stringResource(R.string.otp_notify_method))
 				}
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-					SegmentedButton(
-						enabled = Settings.canDrawOverlays(context),
-						checked = preferredMethod.contains(PresentMethod.Otp.Select),
-						onCheckedChange = {
-							preferredMethod =
-								if (it) preferredMethod.plus(PresentMethod.Otp.Select) else preferredMethod.minus(
-									PresentMethod.Otp.Select
-								)
-							updatePreferredMethods(appSettings, preferredMethod, context)
-						},
-						shape = SegmentedButtonOrder.Last,
-					) {
-						Text(text = stringResource(R.string.otp_show_method))
-					}
+				SegmentedButton(
+					enabled = Settings.canDrawOverlays(context),
+					checked = preferredMethods.contains(PresentMethod.Otp.SELECT),
+					onCheckedChange = {
+						preferredMethods =
+							if (it) preferredMethods.plus(PresentMethod.Otp.SELECT) else preferredMethods.minus(
+								PresentMethod.Otp.SELECT
+							)
+						onPreferredMethodChanged(preferredMethods)
+					},
+					shape = SegmentedButtonOrder.Last,
+				) {
+					Text(text = stringResource(R.string.otp_show_method))
 				}
 			}
 		}
 	}
 }
 
-private fun updatePreferredMethods(
-	appSettings: App.Settings, preferredMethod: Set<String>, context: Context,
+@Composable
+private fun PrivacyAcceptation(
+	onConfirm: () -> Unit,
 ) {
-	appSettings.presentMethods = preferredMethod
-	App.setSettings(context, appSettings)
+	var dismiss by remember { mutableStateOf(false) }
+	if (dismiss) return
+	AlertDialog(icon = {
+		Icon(
+			imageVector = Symbols.Default.Privacy,
+			contentDescription = stringResource(R.string.privacy_dialog_cd)
+		)
+	}, onDismissRequest = {
+		dismiss = true
+	}, title = {
+		Text(
+			text = stringResource(R.string.privacy_dialog_title),
+			style = MaterialTheme.typography.headlineSmall.copy(textDirection = TextDirection.ContentOrRtl)
+		)
+	}, text = {
+		Text(
+			text = stringResource(R.string.privacy_text),
+			style = MaterialTheme.typography.bodyLarge.copy(
+				textDirection = TextDirection.ContentOrRtl, textAlign = TextAlign.Justify
+			)
+		)
+	}, confirmButton = {
+		TextButton(onClick = onConfirm) {
+			Text(text = stringResource(R.string.privacy_accept))
+		}
+	})
 }
 
 private fun grantScreenOverlayPermission(context: Context) {
-	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-		if (!Settings.canDrawOverlays(context)) {
-			startActivityForResult(
-				activity, Intent(
-					Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-					("package:" + context.applicationContext.packageName).toUri()
-				), OVERLAY_PERMISSIONS_REQUEST_CODE, null
-			)
+	if (!Settings.canDrawOverlays(context)) {
+		startActivityForResult(
+			activity, Intent(
+				Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+				("package:" + context.applicationContext.packageName).toUri()
+			), OVERLAY_PERMISSIONS_REQUEST_CODE, null
+		)
 
-		} else {
-			Toast.makeText(
-				context, context.getString(R.string.permission_granted_recently), Toast.LENGTH_SHORT
-			).show()
-		}
+	} else {
+		Toast.makeText(
+			context, context.getString(R.string.permission_granted_recently), Toast.LENGTH_SHORT
+		).show()
 	}
 }
 
@@ -362,24 +439,18 @@ private fun grantNotificationPermission(context: Context) {
 
 @SuppressLint("BatteryLife")
 private fun disableBatteryLimitations(context: Context) {
-	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-		val intent = Intent()
-		val packageName = context.packageName
-		val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-		if (!pm.isIgnoringBatteryOptimizations(packageName)) {
-			intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-			intent.setData("package:$packageName".toUri())
-			context.startActivity(intent, null)
-		} else {
-			Toast.makeText(
-				context,
-				context.getString(R.string.battery_optimization_disabled),
-				Toast.LENGTH_SHORT
-			).show()
-		}
+	val intent = Intent()
+	val packageName = context.packageName
+	val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+	if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+		intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+		intent.setData("package:$packageName".toUri())
+		context.startActivity(intent, null)
 	} else {
 		Toast.makeText(
-			context, context.getString(R.string.device_doesnt_support), Toast.LENGTH_SHORT
+			context,
+			context.getString(R.string.battery_optimization_disabled),
+			Toast.LENGTH_SHORT
 		).show()
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="close_select_otp_code_cd" translatable="false">Close select OTP code</string>
     <string name="select_otp_code_icon_cd" translatable="false">SelectOTP Code Icon</string>
     <string name="back_to_the_main_page_cd" translatable="false">Back to the main page</string>
-    <string name="disclaimer_dialog_cd" translatable="false">Disclaimer Dialog</string>
+    <string name="privacy_dialog_cd" translatable="false">Privacy Dialog</string>
     <string name="code_expiration_time_cd" translatable="false">Code Expiration Time</string>
     <string name="disable_battery_limitations_cd" translatable="false">Disable Battery Limitations</string>
     <string name="notification_permission_request_cd" translatable="false">Grant Post notification permission</string>
@@ -29,7 +29,7 @@
     <string name="otp_code_deleted">رمز پویا با موفقیت حذف شد.</string>
     <string name="empty_code_list">هیچ رمز پویایی تاکنون درخواست نشده است!</string>
     <string name="share_otp_code_text">رمز پویای من در یک تراکنش، در بانک %s، %s می باشد.</string>
-    <string name="disclaimer_text">صالتک هیچگونه سوء استفاده و دخالت به حریم خصوصی و پیامک\u200cهای شما نخواهد کرد و دسترسی به پیامک\u200cها صرفاً به جهت تشخیص و نمایش رمز پویای پیامک شده از طریق بانک مزبور است؛ لازم به ذکر است که پویا خوان فقط پیام های جدید را مشاهده می کند و نیازی به همه پیام های شما ندارد. ضمن اینکه این برنامه هیچ دسترسی به اینترنت نداشته و ضمانت می کند که هرگز اطلاعات شما را به اینترنت ارسال نخواهد کرد.\n* ضمناْ‌ این برنامه به صورت متن باز ارائه شده است.</string>
+    <string name="privacy_text">صالتک هیچگونه سوء استفاده و دخالت به حریم خصوصی و پیامک\u200cهای شما نخواهد کرد و دسترسی به پیامک\u200cها صرفاً به جهت تشخیص و نمایش رمز پویای پیامک شده از طریق بانک مزبور است؛ لازم به ذکر است که پویا خوان فقط پیام های جدید را مشاهده می کند و نیازی به همه پیام های شما ندارد. ضمن اینکه این برنامه هیچ دسترسی به اینترنت نداشته و ضمانت می کند که هرگز اطلاعات شما را به اینترنت ارسال نخواهد کرد.\nهمچنین پویاخوان به صورت متن باز ارائه شده است.</string>
     <string name="memory_leaked_error">برخی از عملکرد های این برنامه برای دستگاه شما، متأسفانه هنوز بهینه نشده است!</string>
     <string name="unknown_bank">بانک ناشناخته</string>
     <string name="your_new_otp_code_is">رمز یکبارمصرف شما %s می باشد.</string>
@@ -40,8 +40,8 @@
     <string name="otp_sms_notification_short_message">برای مشاهده رمز، این را به پایین بکشید.</string>
     <string name="copy_otp_code">کپی کردن</string>
     <string name="otp_sms_window_alert">در حال نمایش پنجره رمز یکبار مصرف</string>
-    <string name="disclaimer_dialog_title">حریم شخصی</string>
-    <string name="discalimer_accept">پذیرش و ادامه</string>
+    <string name="privacy_dialog_title">حریم شخصی</string>
+    <string name="privacy_accept">می پذیرم</string>
     <string name="app_permission_title">نیازمند مجوز دسترسی</string>
     <string name="app_permission_message">پویا خوان برای بررسی کد های رمز پویای دریافتی از طرف دستگاه شما، نیازمند دسترسی به پیام های شماست.</string>
     <string name="otp_notify_channel_title">اعلان رمز یکبار مصرف</string>
@@ -71,5 +71,7 @@
     <string name="copy_otp_code_hint">با زدن روی دکمه پایین، میتوانید رمز خود را کپی کنید.</string>
     <string name="list_otp_codes_title">کدهای یکبارمصرف (رمزهای پویا) دریافت شده</string>
     <string name="otp_code_expired_2">منقضی شده</string>
+	<string name="permission_accept_button">باشه؛ مشکلی نیست</string>
+    <string name="terms">قوانین و مقررات</string>
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,5 +39,3 @@ google-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gs
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-googleProtobuf = { id = "com.google.protobuf", version = "0.9.3" }
-


### PR DESCRIPTION
This commit introduces several improvements to the application's settings management and overall code structure:

- **Asynchronous Settings:** App settings are now loaded and saved asynchronously using coroutines, improving performance and responsiveness.
- **ViewModel for Settings:** Settings are now managed through a ViewModel (`OtpCodesVM`), providing a more robust and testable approach.
- **Refined OTP Presentation Logic:**
    - The `OtpSmsReceiver` now uses a coroutine to handle OTP processing asynchronously.
    - Enum constants for OTP presentation methods (`COPY`, `NOTIFY`, `SELECT`) are now uppercase for better convention.
    - The key for copying OTP codes (`OTP_CODE_COPY_KEY`) is now an uppercase constant.
- **UI Enhancements:**
    - The settings screen (`SettingsView`) now directly interacts with the ViewModel to manage and display settings.
    - A privacy dialog has been added to the settings screen.
    - The terms and conditions link is now accessible from the settings screen.
    - Minor UI adjustments for better clarity and consistency.
- **Code Cleanup and Readability:**
    - Removed unused `DisclaimerAcceptation` composable as privacy is now handled in settings.
    - Renamed `Disclaimer` symbol to `Privacy`.
    - Improved code formatting and removed unnecessary version checks for API levels.
    - The `SelectOtpWindow` now loads app settings asynchronously.
    - Utilized `repeatForever` utility function for continuous background tasks in `OtpCodesVM`.
- **Dependency Update:** Removed the `googleProtobuf` plugin as it's no longer directly used.